### PR TITLE
Ignore notes on build if necessary

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -64,7 +64,9 @@ module.exports = function (config) {
   return {
     passthroughFileCopy: true,
     dir: {
-      input: hasNotes ? 'src/{index.njk,notes.njk}' : 'src/!(notes.njk)',
+      input: hasNotes
+        ? 'src/{index.njk,notes.njk,slides/!(*.notes).md}'
+        : 'src/{notes.njk,slides/!(*.notes).md}',
       output: 'dist'
     }
   }

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -64,9 +64,7 @@ module.exports = function (config) {
   return {
     passthroughFileCopy: true,
     dir: {
-      input: hasNotes
-        ? 'src/{index.njk,notes.njk,slides/!(*.notes).md}'
-        : 'src/{notes.njk,slides/!(*.notes).md}',
+      input: 'src',
       output: 'dist'
     }
   }

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,3 +1,5 @@
+const globalData = require('./src/_data/global.js')
+const hasNotes = globalData.notes
 /**
  * Add a notes property to the slide templates objects.
  * @param {object[]} slides
@@ -51,7 +53,9 @@ module.exports = function (config) {
   })
 
   config.addPassthroughCopy('src/styles')
-  config.addPassthroughCopy('src/scripts')
+  if (hasNotes) {
+    config.addPassthroughCopy('src/scripts')
+  }
 
   config.setBrowserSyncConfig({
     notify: true
@@ -60,7 +64,7 @@ module.exports = function (config) {
   return {
     passthroughFileCopy: true,
     dir: {
-      input: 'src',
+      input: hasNotes ? 'src/{index.njk,notes.njk}' : 'src/!(notes.njk)',
       output: 'dist'
     }
   }

--- a/src/index.njk
+++ b/src/index.njk
@@ -15,5 +15,7 @@
       {% endif %}
     </section>
   {% endfor %}
-  <script src="scripts/slides.js"></script>
+  {% if global.notes %}
+    <script src="scripts/slides.js"></script>
+  {% endif %}
 {% endblock %}

--- a/src/notes.11tydata.js
+++ b/src/notes.11tydata.js
@@ -1,0 +1,7 @@
+const globals = require('./_data/global')
+
+module.exports = function () {
+  return {
+    permalink: globals.notes ? 'notes/index.html' : false
+  }
+}

--- a/src/notes.njk
+++ b/src/notes.njk
@@ -18,5 +18,7 @@
   </section>
 {% endfor %}
 
-<script src="/scripts/notes.js"></script>
+{% if global.notes %}
+  <script src="/scripts/notes.js"></script>
+{% endif %}
 {% endblock %}

--- a/src/notes.njk
+++ b/src/notes.njk
@@ -18,7 +18,5 @@
   </section>
 {% endfor %}
 
-{% if global.notes %}
-  <script src="/scripts/notes.js"></script>
-{% endif %}
+<script src="/scripts/notes.js"></script>
 {% endblock %}

--- a/src/slides/slides.json
+++ b/src/slides/slides.json
@@ -1,0 +1,3 @@
+{
+  "permalink": false
+}


### PR DESCRIPTION
If `global.notes` is `false`:
- don't load the notes-related JavaScript files.
- don't build notes page.